### PR TITLE
Minor edits to support use of cftime in datetime_to_iris_time function

### DIFF
--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -35,6 +35,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Union
 
 import cf_units
+import cftime
 import iris
 import numpy as np
 from iris import Constraint
@@ -144,9 +145,10 @@ def iris_time_to_datetime(
     return datetime_list
 
 
-def datetime_to_iris_time(dt_in: datetime) -> float:
+def datetime_to_iris_time(dt_in: Union[datetime, cftime.DatetimeGregorian]) -> float:
     """
-    Convert python datetime.datetime into seconds since 1970-01-01 00Z.
+    Convert python datetime.datetime or cftime.DatetimeGregorian object into
+    seconds since 1970-01-01 00Z.
 
     Args:
         dt_in:
@@ -155,6 +157,10 @@ def datetime_to_iris_time(dt_in: datetime) -> float:
     Returns:
         Time since epoch in the seconds as desired dtype.
     """
+    if isinstance(dt_in, cftime.DatetimeGregorian):
+        dt_in = datetime(
+            dt_in.year, dt_in.month, dt_in.day, dt_in.hour, dt_in.minute, dt_in.second
+        )
     result = dt_in.replace(tzinfo=timezone.utc).timestamp()
     return np.int64(result)
 

--- a/improver/utilities/temporal.py
+++ b/improver/utilities/temporal.py
@@ -35,14 +35,14 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Union
 
 import cf_units
-import cftime
 import iris
 import numpy as np
+from cftime import DatetimeGregorian
 from iris import Constraint
 from iris.coords import AuxCoord, Coord
 from iris.cube import Cube, CubeList
 from iris.time import PartialDateTime
-from numpy import ndarray
+from numpy import int64, ndarray
 
 from improver import PostProcessingPlugin
 from improver.metadata.check_datatypes import enforce_dtype
@@ -145,7 +145,7 @@ def iris_time_to_datetime(
     return datetime_list
 
 
-def datetime_to_iris_time(dt_in: Union[datetime, cftime.DatetimeGregorian]) -> float:
+def datetime_to_iris_time(dt_in: Union[datetime, DatetimeGregorian]) -> int64:
     """
     Convert python datetime.datetime or cftime.DatetimeGregorian object into
     seconds since 1970-01-01 00Z.
@@ -155,9 +155,9 @@ def datetime_to_iris_time(dt_in: Union[datetime, cftime.DatetimeGregorian]) -> f
             Time to be converted into seconds since 1970-01-01 00Z.
 
     Returns:
-        Time since epoch in the seconds as desired dtype.
+        Time since epoch in the seconds.
     """
-    if isinstance(dt_in, cftime.DatetimeGregorian):
+    if isinstance(dt_in, DatetimeGregorian):
         dt_in = datetime(
             dt_in.year, dt_in.month, dt_in.day, dt_in.hour, dt_in.minute, dt_in.second
         )

--- a/improver_tests/utilities/temporal/test_temporal.py
+++ b/improver_tests/utilities/temporal/test_temporal.py
@@ -33,6 +33,7 @@
 import unittest
 from datetime import datetime
 
+import cftime
 import iris
 import numpy as np
 from iris.cube import Cube, CubeList
@@ -200,14 +201,22 @@ class Test_datetime_to_iris_time(IrisTest):
     def setUp(self):
         """Define datetime for use in tests."""
         self.dt_in = datetime(2017, 2, 17, 6, 0)
+        self.cftime_in = cftime.DatetimeGregorian(2017, 2, 17, hour=6, minute=0)
+        self.expected = 1487311200.0
 
     def test_seconds(self):
         """Test datetime_to_iris_time returns float with expected value
         in seconds"""
         result = datetime_to_iris_time(self.dt_in)
-        expected = 1487311200.0
         self.assertIsInstance(result, np.int64)
-        self.assertEqual(result, expected)
+        self.assertEqual(result, self.expected)
+
+    def test_cftime(self):
+        """Test datetime_to_iris_time returns float with expected value
+        in seconds when a cftime.DatetimeGregorian object is provided."""
+        result = datetime_to_iris_time(self.cftime_in)
+        self.assertIsInstance(result, np.int64)
+        self.assertEqual(result, self.expected)
 
 
 class Test_datetime_constraint(IrisTest):


### PR DESCRIPTION
Addresses https://github.com/metoppv/improver/issues/1540

Description
This PR makes a minor edit to the datetime_to_iris_time function to support cftime.DatetimeGregorian objects being input, as found on Iris time coordinates when using Iris 3. A unit test is also added.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

Closes: https://github.com/metoppv/improver/issues/1540